### PR TITLE
fix setup.py install target (README.txt->.rst)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup_args.update(dict(
     name='imagen',
     version='1.0',
     description='Generic Python library for 0D, 1D, and 2D pattern distributions.',
-    long_description=open('README.txt').read(),
+    long_description=open('README.rst').read(),
     author= "IOAM",
     author_email= "developers@topographica.org",
     maintainer= "IOAM",


### PR DESCRIPTION
before this commit, setup fails as follows

```
14:44@imagen(master)$ python setup.py install --user
Traceback (most recent call last):
  File "setup.py", line 44, in <module>
    long_description=open('README.txt').read(),
IOError: [Errno 2] No such file or directory: 'README.txt'
```

after this commit, the install works
