### PR TITLE
Fixed ComposeChannels and bugs with num_channels()

### DIFF
--- a/imagen/image.py
+++ b/imagen/image.py
@@ -526,16 +526,14 @@ class ScaleChannels(ChannelTransform):
     """
     Scale each channel of an Image PatternGenerator by a different factor. 
 
-    The list of channel factors needs to be the same length as the number of channels.
-    If the factors provided are fewer than the channels of the Image, the remaining channels
-    will not be scaled. If they are more, then only the first N factors are used.
+    The list of channel factors should be the same length as the number of channels.
+    Otherwise, if the factors provided are fewer than the channels of the Image, the
+    remaining channels will not be scaled. If they are more, then only the first N
+    factors are used.
     """
 
     channel_factors = param.Dynamic(default=[1.0,1.0,1.0],doc="""
-        Channel scaling factors. The length of this list sets the
-        number of channels to be created, unless the input_generator
-        already supports multiple channels (in which case the number
-        of its channels is used).""")
+        Channel scaling factors.""")
 
 
     def __call__(self,channel_data):

--- a/imagen/patterngenerator.py
+++ b/imagen/patterngenerator.py
@@ -379,8 +379,7 @@ class ChannelGenerator(PatternGenerator):
 
 
 
-# ALERT: Interface needs to change to support multiple generators, not
-# just rescaling a single one.
+
 class ComposeChannels(ChannelGenerator):
     """
     Create a multi-channel PatternGenerator from another PatternGenerator.


### PR DESCRIPTION
num_channels() is now a bit hacky, but necessary.  Also, the case where it is called without having an image generated first is very narrow and usually happens at most once, at initialization (when it's necessary to know, beforehand, the number of channels of the inputs, in order to construct the higher structures)
