### PR TITLE
Fix Python3 incompatibility in PatternGenerator

### DIFF
--- a/imagen/__init__.py
+++ b/imagen/__init__.py
@@ -1387,7 +1387,7 @@ class PowerSpectrum(PatternGenerator):
 
         # calculate the discrete frequencies possible for the given sample rate.
         sample_rate = self.signal.sample_rate
-        available_frequency_range = np.fft.fftfreq(sample_rate, d=1.0/sample_rate)[0:sample_rate/2]
+        available_frequency_range = np.fft.fftfreq(sample_rate, d=1.0/sample_rate)[0:sample_rate//2]
 
         if not available_frequency_range.min() <= self.min_frequency or not available_frequency_range.max() >= self.max_frequency:
             raise ValueError("Specified frequency interval [%s:%s] is unavailable, available range is [%s:%s]. Adjust to these frequencies or modify the sample rate of the TimeSeries object." %(self.min_frequency, self.max_frequency, available_frequency_range.min(), available_frequency_range.max()))
@@ -1435,7 +1435,7 @@ class PowerSpectrum(PatternGenerator):
         else:
             smoothed_window = signal_window[0:sample_rate]
 
-        amplitudes = (np.abs(np.fft.rfft(smoothed_window))[0:sample_rate/2] + self.offset) * self.scale
+        amplitudes = (np.abs(np.fft.rfft(smoothed_window))[0:sample_rate//2] + self.offset) * self.scale
 
         for index in range(0, self._sheet_dimensions[0]-2):
             start_frequency = self.frequency_spacing[index]

--- a/imagen/__init__.py
+++ b/imagen/__init__.py
@@ -639,7 +639,7 @@ class Sweeper(ChannelGenerator):
                                       reset_period=p.reset_period,
                                       time_fn=p.time_fn)
         pg = p.generator
-        pg.set_dynamic_time_fn(motion_time_fn)
+        pg.param.set_dynamic_time_fn(motion_time_fn)
         motion_orientation = pg.orientation + p.relative_motion_orientation
 
         step = int(p.time_fn() % p.reset_period) + p.step_offset
@@ -650,7 +650,7 @@ class Sweeper(ChannelGenerator):
         try:
             #TFALERT: Not sure whether this is needed
             if(len(self._channel_data)!=len(pg._channel_data)):
-               self._channel_data=copy.deepcopy(pg._channel_data)
+                self._channel_data=copy.deepcopy(pg._channel_data)
 
             # For multichannel pattern generators
             for i in range(len(pg._channel_data)):

--- a/imagen/patterngenerator.py
+++ b/imagen/patterngenerator.py
@@ -216,7 +216,7 @@ class PatternGenerator(param.Parameterized):
         density (or rows and cols), and transforms them according to
         x, y, and orientation.
         """
-        self.debug("bounds=%s, xdensity=%s, ydensity=%s, x=%s, y=%s, orientation=%s",bounds,xdensity,ydensity,x,y,orientation)
+        self.param.debug("bounds=%s, xdensity=%s, ydensity=%s, x=%s, y=%s, orientation=%s",bounds,xdensity,ydensity,x,y,orientation)
         # Generate vectors representing coordinates at which the pattern
         # will be sampled.
 
@@ -413,7 +413,7 @@ class PatternGenerator(param.Parameterized):
 
 # Override class type; must be set here rather than when mask_shape is declared,
 # to avoid referring to class not yet constructed
-PatternGenerator.params('mask_shape').class_=PatternGenerator
+PatternGenerator.param.params('mask_shape').class_=PatternGenerator
 
 
 

--- a/imagen/patterngenerator.py
+++ b/imagen/patterngenerator.py
@@ -174,7 +174,7 @@ class PatternGenerator(param.Parameterized):
             value_dims = {'value_dimensions':[self.z]} if self.z else value_dims
         elif self.num_channels() in [3,4]:
             raster = RGB
-            data = np.dstack(self.channels().values()[1:])
+            data = np.dstack(list(self.channels().values())[1:])
 
         image = raster(data, bounds=self.bounds,
                        **dict(group=self.group,
@@ -402,7 +402,7 @@ class PatternGenerator(param.Parameterized):
 
         elif nchans in [3,4]:
             mode = 'RGB' if nchans==3 else 'RGBA'
-            arr = np.dstack(self.channels(**params_to_override).values()[1:])
+            arr = np.dstack(list(self.channels(**params_to_override).values())[1:])
             arr = (255.0*arr).astype(np.uint8)
 
         else:

--- a/imagen/random.py
+++ b/imagen/random.py
@@ -279,8 +279,8 @@ class RandomDotStereogram(PatternGenerator):
         for i in range(ndots):
             bigimage[y1[i]:y2[i]+1,x1[i]:x2[i]+1] = col[i]
 
-        result = p.offset + p.scale*bigimage[ (ysize/2)+ydisparity:(3*ysize/2)+ydisparity ,
-                                              (xsize/2)+xdisparity:(3*xsize/2)+xdisparity ]
+        result = p.offset + p.scale*bigimage[ (ysize//2)+ydisparity:(3*ysize//2)+ydisparity ,
+                                              (xsize//2)+xdisparity:(3*xsize//2)+xdisparity ]
 
         for of in p.output_fns:
             of(result)

--- a/tests/testpatterngenerator.py
+++ b/tests/testpatterngenerator.py
@@ -230,7 +230,7 @@ class TestSelector(unittest.TestCase):
         self.g1 = Gaussian(x=numbergen.UniformRandom())
         self.g2 = Gaussian(x=numbergen.UniformRandom())
         self.s = Selector(generators=[self.g1,self.g2])
-        self.s.set_dynamic_time_fn(None,'generators')
+        self.s.param.set_dynamic_time_fn(None,'generators')
 
     def test_dynamic_index(self):
         """index should always vary"""


### PR DESCRIPTION
In PatternGenerator `self.channels().values()` was not being converted to a list before accessing by index.